### PR TITLE
テキストフィールドコンポーネントの修正

### DIFF
--- a/assets/color/colors.xml
+++ b/assets/color/colors.xml
@@ -5,6 +5,9 @@
     <color name="secondColor">#D0C9C0</color>
     <color name="accentColor">#6D8B74</color>
     <color name="primaryColor">#EE7D50</color>
+<<<<<<< HEAD
     <color name="disabledColor">#8E8E93</color>
     <color name="white">#FFFFFF</color>
+=======
+>>>>>>> 0a876dd (style: プライマリーカラーの追加)
 </resources>

--- a/lib/presentation/component/custom_text_field.dart
+++ b/lib/presentation/component/custom_text_field.dart
@@ -1,30 +1,72 @@
 import 'package:flutter/material.dart';
 
+import 'package:gap/gap.dart';
+
+import 'package:food_quest/gen/colors.gen.dart';
+
 class CustomTextField extends StatelessWidget {
   const CustomTextField({
+    required this.title,
     required this.controller,
     required this.hintText,
-    this.obscureText = false,
+    this.isObscure = false,
+    super.key,
+  });
+
+  final String title;
+  final TextEditingController controller;
+  final String hintText;
+  final bool isObscure;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: const TextStyle(
+            fontSize: 12,
+          ),
+        ),
+        const Gap(4),
+        BuildTextField(
+          controller: controller,
+          isObscure: isObscure,
+          hintText: hintText,
+        ),
+      ],
+    );
+  }
+}
+
+class BuildTextField extends StatelessWidget {
+  const BuildTextField({
+    required this.controller,
+    required this.isObscure,
+    required this.hintText,
     super.key,
   });
 
   final TextEditingController controller;
+  final bool isObscure;
   final String hintText;
-  final bool obscureText;
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
       controller: controller,
-      obscureText: obscureText,
+      obscureText: isObscure,
       decoration: InputDecoration(
-        filled: true,
-        fillColor: const Color(0xffe3dfdc),
-        contentPadding:
-            const EdgeInsets.symmetric(vertical: 24, horizontal: 24),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(40),
-          borderSide: BorderSide.none,
+        enabledBorder: const UnderlineInputBorder(
+          borderSide: BorderSide(
+            color: AppColor.textColor, //通常時
+          ),
+        ),
+        focusedBorder: const UnderlineInputBorder(
+          borderSide: BorderSide(
+            color: AppColor.primaryColor, //入力中
+          ),
         ),
         hintText: hintText,
       ),

--- a/lib/presentation/screen/auth/sign_up_screen.dart
+++ b/lib/presentation/screen/auth/sign_up_screen.dart
@@ -35,6 +35,7 @@ class SignUpScreen extends HookConsumerWidget {
                 Padding(
                   padding: const EdgeInsets.only(top: 28),
                   child: CustomTextField(
+                    title: 'メールアドレス',
                     controller: authNotifier.emailController,
                     hintText: 'emailを入力してください',
                   ),
@@ -42,7 +43,8 @@ class SignUpScreen extends HookConsumerWidget {
                 Padding(
                   padding: const EdgeInsets.only(top: 28),
                   child: CustomTextField(
-                    obscureText: true,
+                    title: 'パスワード',
+                    isObscure: true,
                     controller: authNotifier.passwordController,
                     hintText: 'passwordを入力してください',
                   ),
@@ -54,7 +56,8 @@ class SignUpScreen extends HookConsumerWidget {
                 Padding(
                   padding: const EdgeInsets.only(top: 28),
                   child: CustomTextField(
-                    obscureText: true,
+                    title: '名前',
+                    isObscure: true,
                     controller: authNotifier.nameController,
                     hintText: '名前を入力してください',
                   ),


### PR DESCRIPTION
## 概要
(このセクションでは、このPRの目的と概要を簡潔に説明してください。)

テキストフィールドコンポーネントをFigmaのUIと一致させること

## 変更点 (あれば)

(このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。)

- UIをFigmaに合わせました(https://www.figma.com/file/hPT7kJEDavgNj1U9VX9nyK/%E3%82%AD%E3%83%A3%E3%83%A9%E3%83%90%E3%83%B3%E3%83%8F%E3%83%83%E3%82%AB%E3%82%BD%E3%83%B3-UI?type=design&node-id=575-7260&mode=dev)
- 入力中は下線部の色が変化するようにしています

**できなかった点**
パスワード入力時、テキストを表示・非表示にする機能

## スクショ(動画)
|  Figma  |  app  |
| ------------- | ------------- |
| <img width="748" alt="スクリーンショット 2023-10-05 2 48 03" src="https://github.com/tenpei-peso/food_quest/assets/104209788/f0779002-c1e3-4280-942f-83c17dee82ce">   | <img width="322" alt="スクリーンショット 2023-10-05 2 43 40" src="https://github.com/tenpei-peso/food_quest/assets/104209788/1d1b92ea-891a-4f34-a4ae-01bd48d5a2c6">   |



